### PR TITLE
Move some parts of domainData to siloDomainData

### DIFF
--- a/frontend/src/Root.js
+++ b/frontend/src/Root.js
@@ -8,6 +8,9 @@ import App from './App';
 import store from './common/store';
 import storeConfig from './common/config/store';
 
+import reduxSync from './public/utils/redux-sync';
+
+
 export default class Root extends React.Component {
     constructor(props) {
         super(props);
@@ -21,7 +24,12 @@ export default class Root extends React.Component {
     componentWillMount() {
         console.log('Mounting Root');
         const afterRehydrateCallback = () => this.setState({ rehydrated: true });
-        persistStore(this.store, storeConfig, afterRehydrateCallback);
+        const persistor = persistStore(this.store, storeConfig, afterRehydrateCallback);
+        reduxSync(
+            persistor,
+            ['siloDomainData'],
+            storeConfig.keyPrefix,
+        );
     }
 
     render() {

--- a/frontend/src/common/action-creators/domainData.js
+++ b/frontend/src/common/action-creators/domainData.js
@@ -8,8 +8,6 @@ import {
     SET_USER_GROUP,
     UNSET_USER_GROUP,
     DUMMY_ACTION,
-    SET_ACTIVE_PROJECT,
-    SET_ACTIVE_COUNTRY,
     SET_COUNTRIES,
     ADD_NEW_COUNTRY,
     UNSET_REGION,
@@ -62,16 +60,6 @@ export const unSetUserGroupAction = ({ userId, userGroupId }) => ({
     type: UNSET_USER_GROUP,
     userId,
     userGroupId,
-});
-
-export const setActiveProjectAction = ({ activeProject }) => ({
-    type: SET_ACTIVE_PROJECT,
-    activeProject,
-});
-
-export const setActiveCountryAction = ({ activeCountry }) => ({
-    type: SET_ACTIVE_COUNTRY,
-    activeCountry,
 });
 
 export const unSetRegionAction = ({ regionId }) => ({

--- a/frontend/src/common/action-creators/siloDomainData.js
+++ b/frontend/src/common/action-creators/siloDomainData.js
@@ -1,0 +1,15 @@
+import {
+    SET_ACTIVE_PROJECT,
+    SET_ACTIVE_COUNTRY,
+} from '../action-types/siloDomainData';
+
+
+export const setActiveProjectAction = ({ activeProject }) => ({
+    type: SET_ACTIVE_PROJECT,
+    activeProject,
+});
+
+export const setActiveCountryAction = ({ activeCountry }) => ({
+    type: SET_ACTIVE_COUNTRY,
+    activeCountry,
+});

--- a/frontend/src/common/action-types/domainData.js
+++ b/frontend/src/common/action-types/domainData.js
@@ -9,11 +9,7 @@ export const SET_USER_GROUPS = 'domain-data/SET_USER_GROUPS';
 export const SET_USER_GROUP = 'domain-data/SET_USER_GROUP';
 export const UNSET_USER_GROUP = 'domain-data/UNSET_USER_GROUP';
 
-
-export const SET_ACTIVE_PROJECT = 'domain-data/SET_ACTIVE_PROJECT';
-export const SET_ACTIVE_COUNTRY = 'domain-data/SET_ACTIVE_COUNTRY';
 export const UNSET_REGION = 'domain-data/UNSET_REGION';
-
 export const ADD_NEW_COUNTRY = 'domain-data/ADD_NEW_COUNTRY';
 
 export const SET_LEADS = 'domain-data/SET_LEADS';

--- a/frontend/src/common/action-types/siloDomainData.js
+++ b/frontend/src/common/action-types/siloDomainData.js
@@ -1,0 +1,2 @@
+export const SET_ACTIVE_PROJECT = 'domain-data/SET_ACTIVE_PROJECT';
+export const SET_ACTIVE_COUNTRY = 'domain-data/SET_ACTIVE_COUNTRY';

--- a/frontend/src/common/config/store.js
+++ b/frontend/src/common/config/store.js
@@ -1,8 +1,8 @@
-import localforage from 'localforage';
+// import localforage from 'localforage';
 
 const storeConfig = {
-    blacklist: ['websocket', 'domainData', 'datetime', 'navbar'],
-    storage: localforage,
+    // blacklist: ['websocket', 'domainData', 'datetime', 'navbar'],
+    // storage: localforage,
     keyPrefix: 'deeper-',
     // TODO: add transforms
 };

--- a/frontend/src/common/initial-state/domainData.js
+++ b/frontend/src/common/initial-state/domainData.js
@@ -432,9 +432,5 @@ const initialDomainDataState = {
             },
         ],
     },
-
-    activeProject: 1,
-
-    activeCountry: undefined,
 };
 export default initialDomainDataState;

--- a/frontend/src/common/initial-state/siloDomainData.js
+++ b/frontend/src/common/initial-state/siloDomainData.js
@@ -1,0 +1,6 @@
+const initialSiloDomainData = {
+    activeProject: 1,
+    activeCountry: undefined,
+};
+
+export default initialSiloDomainData;

--- a/frontend/src/common/reducers/domainData.js
+++ b/frontend/src/common/reducers/domainData.js
@@ -8,17 +8,12 @@ import {
     SET_USER_GROUP,
     UNSET_USER_GROUP,
     DUMMY_ACTION,
-    SET_ACTIVE_PROJECT,
-    SET_ACTIVE_COUNTRY,
     UNSET_REGION,
     ADD_NEW_COUNTRY,
     SET_COUNTRIES,
     SET_LEADS,
     SET_LEAD_FILTER_OPTIONS,
 } from '../action-types/domainData';
-import {
-    activeProjectSelector,
-} from '../selectors/domainData';
 
 import initialDomainDataState from '../initial-state/domainData';
 import update from '../../public/utils/immutable-update';
@@ -108,14 +103,6 @@ const domainDataReducer = (state = initialDomainDataState, action) => {
             return update(state, settings);
         }
         case SET_USER_PROJECTS: {
-            let activeProject = activeProjectSelector({ domainData: state });
-            if (action.projects && action.projects.length > 0) {
-                const key = action.projects.findIndex(project => project.id === activeProject);
-                if (key < 0) {
-                    activeProject = action.projects[0].id;
-                }
-            }
-
             const projects = action.projects.reduce((acc, project) => (
                 {
                     ...acc,
@@ -133,9 +120,6 @@ const domainDataReducer = (state = initialDomainDataState, action) => {
                             $set: action.projects.map(project => project.id),
                         } },
                     } },
-                },
-                activeProject: {
-                    $set: activeProject,
                 },
             };
             return update(state, settings);
@@ -270,22 +254,6 @@ const domainDataReducer = (state = initialDomainDataState, action) => {
             return update(state, settings);
         }
 
-        case SET_ACTIVE_PROJECT: {
-            const settings = {
-                activeProject: {
-                    $set: action.activeProject,
-                },
-            };
-            return update(state, settings);
-        }
-        case SET_ACTIVE_COUNTRY: {
-            const settings = {
-                activeCountry: {
-                    $set: action.activeCountry,
-                },
-            };
-            return update(state, settings);
-        }
         case ADD_NEW_COUNTRY: {
             const settings = {
                 countries: { $autoArray: {

--- a/frontend/src/common/reducers/index.js
+++ b/frontend/src/common/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import authReducer from './auth';
 import domainDataReducer from './domainData';
+import siloDomainDataReducer from './siloDomainData';
 import datetimeReducer from './datetime';
 import navbarReducer from './navbar';
 
@@ -8,6 +9,7 @@ const appReducer = combineReducers({
     auth: authReducer,
     domainData: domainDataReducer,
     datetime: datetimeReducer,
+    siloDomainData: siloDomainDataReducer,
     navbar: navbarReducer,
 });
 

--- a/frontend/src/common/reducers/siloDomainData.js
+++ b/frontend/src/common/reducers/siloDomainData.js
@@ -1,0 +1,56 @@
+import {
+    SET_ACTIVE_COUNTRY,
+    SET_ACTIVE_PROJECT,
+} from '../action-types/siloDomainData';
+
+import {
+    SET_USER_PROJECTS,
+} from '../action-types/domainData';
+
+import {
+    activeProjectSelector,
+} from '../selectors/siloDomainData';
+
+import initialSiloDomainData from '../initial-state/siloDomainData';
+import update from '../../public/utils/immutable-update';
+
+const siloDomainDataReducer = (state = initialSiloDomainData, action) => {
+    switch (action.type) {
+        case SET_ACTIVE_PROJECT: {
+            const settings = {
+                activeProject: {
+                    $set: action.activeProject,
+                },
+            };
+            return update(state, settings);
+        }
+        case SET_USER_PROJECTS: {
+            let activeProject = activeProjectSelector({ siloDomainData: state });
+            if (action.projects && action.projects.length > 0) {
+                const key = action.projects.findIndex(project => project.id === activeProject);
+                if (key < 0) {
+                    activeProject = action.projects[0].id;
+                }
+            }
+
+            const settings = {
+                activeProject: {
+                    $set: activeProject,
+                },
+            };
+            return update(state, settings);
+        }
+        case SET_ACTIVE_COUNTRY: {
+            const settings = {
+                activeCountry: {
+                    $set: action.activeCountry,
+                },
+            };
+            return update(state, settings);
+        }
+        default:
+            return state;
+    }
+};
+
+export default siloDomainDataReducer;

--- a/frontend/src/common/redux.js
+++ b/frontend/src/common/redux.js
@@ -1,8 +1,10 @@
 export * from './action-creators/auth';
 export * from './action-creators/domainData';
+export * from './action-creators/siloDomainData';
 export * from './action-creators/navbar';
 
 export * from './selectors/auth';
 export * from './selectors/datetime';
 export * from './selectors/domainData';
+export * from './selectors/siloDomainData';
 export * from './selectors/navbar';

--- a/frontend/src/common/selectors/domainData.js
+++ b/frontend/src/common/selectors/domainData.js
@@ -15,12 +15,6 @@ export const countryIdFromProps = (state, { countryId }) => countryId;
 
 // Using state
 
-export const activeProjectSelector = ({ domainData }) => (
-    domainData.activeProject
-);
-export const activeCountrySelector = ({ domainData }) => (
-    domainData.activeCountry
-);
 export const leadsSelector = ({ domainData }) => (
     domainData.leads || emptyObject
 );
@@ -55,40 +49,6 @@ export const adminLevelSelector = createSelector(
     (adminLevels, countryId) => (
         adminLevels[countryId] || emptyList
     ),
-);
-
-export const countriesListSelector = createSelector(
-    countriesSelector,
-    countries => (
-        countries && Object.keys(countries).reduce((acc, countryId) => {
-            if (countries[countryId]) {
-                acc.push(countries[countryId]);
-            }
-            return acc;
-        }, [])
-    ) || emptyList,
-);
-
-// FIXME: rename to countryDetailForCountrySelector
-export const countryDetailSelector = createSelector(
-    countriesListSelector,
-    activeCountrySelector,
-    (countries, activeCountry) => (
-        countries.find(country => country.id === activeCountry) || emptyObject
-    ),
-);
-
-export const projectDetailsSelector = createSelector(
-    projectsSelector,
-    activeProjectSelector,
-    (projects, activeProject) => projects[activeProject] || emptyObject,
-);
-
-export const usersInformationListSelector = createSelector(
-    usersSelector,
-    users => (Object.keys(users).map(id =>
-        users[id].information,
-    ) || emptyList).filter(d => d),
 );
 
 // Selector depending on user id from route (url)
@@ -148,35 +108,4 @@ export const currentUserProjectsSelector = createSelector(
             projects[projectId] || emptyObject
         ))
     ) || emptyList),
-);
-
-// Selector depending on project id from state (active project)
-
-export const leadsForProjectSelector = createSelector(
-    activeProjectSelector,
-    leadsSelector,
-    (activeProject, leads) => (leads[activeProject] || emptyList),
-);
-
-export const totalLeadsCountForProjectSelector = createSelector(
-    activeProjectSelector,
-    totalLeadsCountSelector,
-    (activeProject, totalLeadsCount) => (totalLeadsCount[activeProject] || 0),
-);
-
-export const leadFilterOptionsForProjectSelector = createSelector(
-    activeProjectSelector,
-    leadFilterOptionsSelector,
-    (activeProject, leadFilterOptions) => (leadFilterOptions[activeProject] || emptyObject),
-);
-
-// Selector depending on user id from state (logged-in user)
-// and on project id from state (active project)
-
-export const currentUserActiveProjectSelector = createSelector(
-    currentUserProjectsSelector,
-    activeProjectSelector,
-    (currentUserProjects, activeProject) => (
-        currentUserProjects.find(project => project.id === activeProject) || emptyObject
-    ),
 );

--- a/frontend/src/common/selectors/siloDomainData.js
+++ b/frontend/src/common/selectors/siloDomainData.js
@@ -1,0 +1,70 @@
+import { createSelector } from 'reselect';
+import {
+    countriesSelector,
+    currentUserProjectsSelector,
+    leadFilterOptionsSelector,
+    leadsSelector,
+    projectsSelector,
+    totalLeadsCountSelector,
+} from './domainData';
+
+
+// NOTE: Use these to make sure reference don't change
+const emptyList = [];
+const emptyObject = {};
+
+// Using state
+
+export const activeProjectSelector = ({ siloDomainData }) => (
+    siloDomainData.activeProject
+);
+
+export const activeCountrySelector = ({ siloDomainData }) => (
+    siloDomainData.activeCountry
+);
+
+// FIXME: rename to countryDetailForCountrySelector
+export const countryDetailSelector = createSelector(
+    countriesSelector,
+    activeCountrySelector,
+    (countries, activeCountry) => (
+        countries.find(country => country.id === activeCountry) || emptyObject
+    ),
+);
+
+export const projectDetailsSelector = createSelector(
+    projectsSelector,
+    activeProjectSelector,
+    (projects, activeProject) => projects[activeProject] || emptyObject,
+);
+
+// Selector depending on project id from state (active project)
+
+export const leadsForProjectSelector = createSelector(
+    activeProjectSelector,
+    leadsSelector,
+    (activeProject, leads) => (leads[activeProject] || emptyList),
+);
+
+export const totalLeadsCountForProjectSelector = createSelector(
+    activeProjectSelector,
+    totalLeadsCountSelector,
+    (activeProject, totalLeadsCount) => (totalLeadsCount[activeProject] || 0),
+);
+
+export const leadFilterOptionsForProjectSelector = createSelector(
+    activeProjectSelector,
+    leadFilterOptionsSelector,
+    (activeProject, leadFilterOptions) => (leadFilterOptions[activeProject] || emptyObject),
+);
+
+// Selector depending on user id from state (logged-in user)
+// and on project id from state (active project)
+
+export const currentUserActiveProjectSelector = createSelector(
+    currentUserProjectsSelector,
+    activeProjectSelector,
+    (currentUserProjects, activeProject) => (
+        currentUserProjects.find(project => project.id === activeProject) || emptyObject
+    ),
+);


### PR DESCRIPTION
Redux-Sync is now used to sync states between tabs, however
`siloDomainData` is skipped during sync. This allows browser tab
specific UI states while other data are kept in sync.