### PR TITLE
Fix distinction between regions and countries

### DIFF
--- a/frontend/src/common/action-creators/domainData.js
+++ b/frontend/src/common/action-creators/domainData.js
@@ -10,8 +10,8 @@ import {
     SET_USERS_MEMBERSHIP,
     UNSET_USER_MEMBERSHIP,
     DUMMY_ACTION,
-    SET_COUNTRIES,
-    ADD_NEW_COUNTRY,
+    SET_REGIONS,
+    ADD_NEW_REGION,
     UNSET_REGION,
     SET_LEADS,
     SET_LEAD_FILTER_OPTIONS,
@@ -94,14 +94,14 @@ export const setLeadFilterOptionsAction = ({ projectId, leadFilterOptions }) => 
     leadFilterOptions,
 });
 
-export const setCountriesAction = ({ countries }) => ({
-    type: SET_COUNTRIES,
-    countries,
+export const setRegionsAction = ({ regions }) => ({
+    type: SET_REGIONS,
+    regions,
 });
 
-export const addNewCountryAction = ({ countryDetail }) => ({
-    type: ADD_NEW_COUNTRY,
-    countryDetail,
+export const addNewRegionAction = ({ regionDetail }) => ({
+    type: ADD_NEW_REGION,
+    regionDetail,
 });
 
 export const dummyAction = () => ({

--- a/frontend/src/common/action-types/domainData.js
+++ b/frontend/src/common/action-types/domainData.js
@@ -12,9 +12,9 @@ export const SET_USERS_MEMBERSHIP = 'domain-data/SET_USERS_MEMBERSHIP';
 export const UNSET_USER_MEMBERSHIP = 'domain-data/UNSET_USER_MEMBERSHIP';
 
 export const UNSET_REGION = 'domain-data/UNSET_REGION';
-export const ADD_NEW_COUNTRY = 'domain-data/ADD_NEW_COUNTRY';
+export const ADD_NEW_REGION = 'domain-data/ADD_NEW_REGION';
 
 export const SET_LEADS = 'domain-data/SET_LEADS';
 export const SET_LEAD_FILTER_OPTIONS = 'domain-data/SET_LEAD_FILTER_OPTIONS';
 
-export const SET_COUNTRIES = 'domain-data/SET_COUNTRIES';
+export const SET_REGIONS = 'domain-data/SET_REGIONS';

--- a/frontend/src/common/initial-state/domainData.js
+++ b/frontend/src/common/initial-state/domainData.js
@@ -74,7 +74,7 @@ const initialDomainDataState = {
             userGroups: [1, 2],
         },
     },
-    countries: {
+    regions: {
         /*
         1: { id: 1, title: 'Afghanistan', code: 'AFG' },
         2: { id: 2, title: 'Aland Islands', code: 'ALA' },

--- a/frontend/src/common/reducers/domainData.js
+++ b/frontend/src/common/reducers/domainData.js
@@ -11,8 +11,8 @@ import {
     UNSET_USER_MEMBERSHIP,
     DUMMY_ACTION,
     UNSET_REGION,
-    ADD_NEW_COUNTRY,
-    SET_COUNTRIES,
+    ADD_NEW_REGION,
+    SET_REGIONS,
     SET_LEADS,
     SET_LEAD_FILTER_OPTIONS,
 } from '../action-types/domainData';
@@ -267,25 +267,25 @@ const domainDataReducer = (state = initialDomainDataState, action) => {
             };
             return update(state, settings);
         }
-        case SET_COUNTRIES: {
-            const countries = action.countries.reduce((acc, country) => (
+        case SET_REGIONS: {
+            const regions = action.regions.reduce((acc, region) => (
                 {
                     ...acc,
-                    [country.id]: { $auto: {
-                        $set: country,
+                    [region.id]: { $auto: {
+                        $set: region,
                     } },
                 }
             ), {});
 
             const settings = {
-                countries,
+                regions,
             };
             return update(state, settings);
         }
 
         case UNSET_REGION: {
             const settings = {
-                countries: {
+                regions: {
                     [action.regionId]: { $auto: {
                         $set: undefined,
                     } },
@@ -294,11 +294,11 @@ const domainDataReducer = (state = initialDomainDataState, action) => {
             return update(state, settings);
         }
 
-        case ADD_NEW_COUNTRY: {
+        case ADD_NEW_REGION: {
             const settings = {
-                countries: { $autoArray: {
-                    [action.countryDetail.id]: { $auto: {
-                        $merge: action.countryDetail,
+                regions: { $autoArray: {
+                    [action.regionDetail.id]: { $auto: {
+                        $merge: action.regionDetail,
                     } },
                 } },
             };

--- a/frontend/src/common/schema/regions.js
+++ b/frontend/src/common/schema/regions.js
@@ -1,10 +1,10 @@
 const regionSchema = [];
 
 {
-    const name = 'country';
+    const name = 'region';
     const schema = {
         doc: {
-            name: 'Country',
+            name: 'Region',
             description: 'One of the main entities',
         },
         extends: 'dbentity',
@@ -19,17 +19,17 @@ const regionSchema = [];
 }
 
 {
-    const name = 'countriesGetResponse';
+    const name = 'regionsGetResponse';
     const schema = {
         doc: {
-            name: 'Countries Get Response',
+            name: 'Regions Get Response',
             description: 'Response for GET /regions/',
         },
         fields: {
             count: { type: 'uint', required: true },
             next: { type: 'string' },
             previous: { type: 'string' },
-            results: { type: 'array.country', required: true },
+            results: { type: 'array.region', required: true },
         },
     };
     regionSchema.push({ name, schema });
@@ -39,10 +39,10 @@ const regionSchema = [];
     const name = 'regionCreateResponse';
     const schema = {
         doc: {
-            name: 'Country Post Response',
+            name: 'Region Post Response',
             description: 'Response for Post',
         },
-        extends: 'country',
+        extends: 'region',
     };
     regionSchema.push({ name, schema });
 }

--- a/frontend/src/common/selectors/domainData.js
+++ b/frontend/src/common/selectors/domainData.js
@@ -26,12 +26,7 @@ export const regionsSelector = ({ domainData }) => (
 export const countriesListSelector = createSelector(
     regionsSelector,
     regions => (
-        regions && Object.keys(regions).reduce((acc, regionId) => {
-            if (regions[regionId] && regions[regionId].public) {
-                acc.push(regions[regionId]);
-            }
-            return acc;
-        }, [])
+        regions && Object.values(regions).filter(region => region && region.public)
     ) || emptyList,
 );
 

--- a/frontend/src/common/selectors/domainData.js
+++ b/frontend/src/common/selectors/domainData.js
@@ -18,16 +18,17 @@ export const countryIdFromProps = (state, { countryId }) => countryId;
 export const leadsSelector = ({ domainData }) => (
     domainData.leads || emptyObject
 );
-export const countriesSelector = ({ domainData }) => (
-    domainData.countries || emptyObject
+
+export const regionsSelector = ({ domainData }) => (
+    domainData.regions || emptyObject
 );
 
 export const countriesListSelector = createSelector(
-    countriesSelector,
-    countries => (
-        countries && Object.keys(countries).reduce((acc, countryId) => {
-            if (countries[countryId]) {
-                acc.push(countries[countryId]);
+    regionsSelector,
+    regions => (
+        regions && Object.keys(regions).reduce((acc, regionId) => {
+            if (regions[regionId] && regions[regionId].public) {
+                acc.push(regions[regionId]);
             }
             return acc;
         }, [])

--- a/frontend/src/common/selectors/siloDomainData.js
+++ b/frontend/src/common/selectors/siloDomainData.js
@@ -27,8 +27,8 @@ export const activeCountrySelector = ({ siloDomainData }) => (
 export const countryDetailSelector = createSelector(
     countriesListSelector,
     activeCountrySelector,
-    (countries, activeCountry) => (
-        countries.find(country => country.id === activeCountry) || emptyObject
+    (regions, activeCountry) => (
+        regions.find(country => country.id === activeCountry) || emptyObject
     ),
 );
 

--- a/frontend/src/topic/Country/components/AddCountry/index.js
+++ b/frontend/src/topic/Country/components/AddCountry/index.js
@@ -24,14 +24,14 @@ import {
 import {
     tokenSelector,
 
-    addNewCountryAction,
+    addNewRegionAction,
 } from '../../../../common/redux';
 
 import styles from './styles.scss';
 
 const propTypes = {
     token: PropTypes.object.isRequired, // eslint-disable-line
-    addNewCountry: PropTypes.func.isRequired,
+    addNewRegion: PropTypes.func.isRequired,
     onModalClose: PropTypes.func.isRequired,
 };
 
@@ -40,7 +40,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    addNewCountry: params => dispatch(addNewCountryAction(params)),
+    addNewRegion: params => dispatch(addNewRegionAction(params)),
 });
 
 @connect(mapStateToProps, mapDispatchToProps)
@@ -93,8 +93,8 @@ export default class AddCountry extends React.PureComponent {
             .success((response) => {
                 try {
                     schema.validate(response, 'regionCreateResponse');
-                    this.props.addNewCountry({
-                        countryDetail: response,
+                    this.props.addNewRegion({
+                        regionDetail: response,
                     });
                     this.props.onModalClose();
                     browserHistory.push(`/countrypanel/${response.id}`);

--- a/frontend/src/topic/Country/views/index.js
+++ b/frontend/src/topic/Country/views/index.js
@@ -36,7 +36,7 @@ import {
     setNavbarStateAction,
 
     setActiveCountryAction,
-    setCountriesAction,
+    setRegionsAction,
 } from '../../../common/redux';
 
 import CountryDetail from '../components/CountryDetail';
@@ -51,7 +51,7 @@ const propTypes = {
             countryId: PropTypes.string,
         }),
     }),
-    setCountries: PropTypes.func.isRequired,
+    setRegions: PropTypes.func.isRequired,
     setActiveCountry: PropTypes.func.isRequired,
     setNavbarState: PropTypes.func.isRequired,
     token: PropTypes.object.isRequired, // eslint-disable-line
@@ -75,7 +75,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-    setCountries: params => dispatch(setCountriesAction(params)),
+    setRegions: params => dispatch(setRegionsAction(params)),
     setActiveCountry: params => dispatch(setActiveCountryAction(params)),
     setNavbarState: params => dispatch(setNavbarStateAction(params)),
 });
@@ -112,9 +112,9 @@ export default class CountryPanel extends React.PureComponent {
             })
             .success((response) => {
                 try {
-                    schema.validate(response, 'countriesGetResponse');
-                    this.props.setCountries({
-                        countries: response.results,
+                    schema.validate(response, 'regionsGetResponse');
+                    this.props.setRegions({
+                        regions: response.results,
                     });
                 } catch (er) {
                     console.error(er);


### PR DESCRIPTION
When country panel in opened all the regions are pulled.
Only the public ones are shown in country panel.
Countries schema changed to regions schema.
Add country, remove country actions changed to add region and remove
region.
Changed countries/coutry to regions/region when necessary.