### PR TITLE
Fix the server error caused in the geo tasks

### DIFF
--- a/backend/geo/tasks.py
+++ b/backend/geo/tasks.py
@@ -1,5 +1,4 @@
 from celery import shared_task
-from django.conf import settings
 from django.contrib.gis.gdal import DataSource
 from django.contrib.gis.geos import (
     GEOSGeometry,
@@ -11,7 +10,7 @@ from geo.models import Region, AdminLevel, GeoArea
 from redis_store import redis
 
 import reversion
-import os
+import tempfile
 
 import traceback
 import logging
@@ -108,10 +107,10 @@ def _load_geo_areas(region_id):
         while admin_level:
             geo_shape_file = admin_level.geo_shape_file
             if geo_shape_file:
-                data_source = DataSource(os.path.join(
-                    settings.MEDIA_ROOT,
-                    geo_shape_file.file.name
-                ))
+                f = tempfile.NamedTemporaryFile()
+                f.write(geo_shape_file.file.read())
+                data_source = DataSource(f.name)
+                f.close()
                 if data_source.layer_count == 1:
                     layer = data_source[0]
 


### PR DESCRIPTION
Since DataSource only accepts the system filename but server doesn't
necessarily store the files locally,  we first create a temporary
file with the same content and use that temporary file instead.