### PR TITLE
Fix project and lead options api

### DIFF
--- a/backend/lead/views.py
+++ b/backend/lead/views.py
@@ -183,10 +183,13 @@ class LeadOptionsView(views.APIView):
 
         options = {}
 
+        def _filter_by_projects(qs, projects):
+            for p in projects:
+                qs = qs.filter(project=p)
+            return qs
+
         if (fields is None or 'assignee' in fields):
-            assignee = User.objects.filter(
-                project__in=projects,
-            )
+            assignee = _filter_by_projects(User.objects, projects)
             options['assignee'] = [
                 {
                     'key': user.id,

--- a/backend/project/views.py
+++ b/backend/project/views.py
@@ -88,11 +88,14 @@ class ProjectOptionsView(APIView):
 
         options = {}
 
+        def _filter_by_projects(qs, projects):
+            for p in projects:
+                qs = qs.filter(project=p)
+            return qs
+
         if (fields is None or 'regions' in fields):
             if projects:
-                regions1 = Region.objects.filter(
-                    project__in=projects
-                )
+                regions1 = _filter_by_projects(Region.objects, projects)
             else:
                 regions1 = Region.objects.none()
             regions2 = Region.get_for(request.user).distinct()
@@ -107,9 +110,7 @@ class ProjectOptionsView(APIView):
 
         if (fields is None or 'user_groups' in fields):
             if projects:
-                user_groups1 = UserGroup.objects.filter(
-                    project__in=projects
-                )
+                user_groups1 = _filter_by_projects(UserGroup.objects, projects)
             else:
                 user_groups1 = UserGroup.objects.none()
             user_groups2 = UserGroup.get_modifiable_for(request.user)\

--- a/frontend/src/common/schema/users.js
+++ b/frontend/src/common/schema/users.js
@@ -1,5 +1,8 @@
 const userSchema = [];
 
+// Email types changed to string because large number of
+// migrated users do not have valid email
+
 {
     const name = 'user-s';
     const schema = {
@@ -9,7 +12,7 @@ const userSchema = [];
         },
         fields: {
             displayName: { type: 'string', required: true },
-            email: { type: 'email', required: true },
+            email: { type: 'string', required: true },
             id: { type: 'uint', required: true },
         },
     };
@@ -26,7 +29,7 @@ const userSchema = [];
         fields: {
             displayName: { type: 'string', required: true },
             displayPicture: { type: 'uint' }, // id
-            email: { type: 'email', required: true },
+            email: { type: 'string', required: true },
             firstName: { type: 'string', required: true },
             id: { type: 'uint', required: true },
             lastName: { type: 'string', required: true },
@@ -95,7 +98,7 @@ const userSchema = [];
             description: 'Response for POST /password/reset/',
         },
         fields: {
-            email: { type: 'email', required: true },
+            email: { type: 'string', required: true },
         },
     };
     userSchema.push({ name, schema });


### PR DESCRIPTION
When multiple project is selected, return intersection of options rather
than union.

Also set email schema of users as string rather than email because many
migrated users do not have valid email addresses.